### PR TITLE
Replace tutorials with Coming Soon page

### DIFF
--- a/src/pages/tutorials/[...slug].astro
+++ b/src/pages/tutorials/[...slug].astro
@@ -1,31 +1,12 @@
 ---
 import { getCollection } from 'astro:content';
-import TutorialLayout from '../../layouts/TutorialLayout.astro';
 
 export async function getStaticPaths() {
   const tutorials = await getCollection('tutorials');
-  const sorted = tutorials.sort((a, b) => a.data.order - b.data.order);
-
-  return sorted.map((tutorial, index) => ({
+  return tutorials.map((tutorial) => ({
     params: { slug: tutorial.slug },
-    props: {
-      tutorial,
-      prev: index > 0 ? { title: sorted[index - 1].data.title, slug: sorted[index - 1].slug } : null,
-      next: index < sorted.length - 1 ? { title: sorted[index + 1].data.title, slug: sorted[index + 1].slug } : null,
-    },
   }));
 }
-
-const { tutorial, prev, next } = Astro.props;
-const { Content, headings } = await tutorial.render();
 ---
 
-<TutorialLayout
-  title={tutorial.data.title}
-  description={tutorial.data.description}
-  headings={headings}
-  prev={prev}
-  next={next}
->
-  <Content />
-</TutorialLayout>
+<meta http-equiv="refresh" content="0; url=/tutorials" />

--- a/src/pages/tutorials/index.astro
+++ b/src/pages/tutorials/index.astro
@@ -1,9 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-
-const allTutorials = await getCollection('tutorials');
-const tutorials = allTutorials.sort((a, b) => a.data.order - b.data.order);
 ---
 
 <BaseLayout
@@ -12,37 +8,50 @@ const tutorials = allTutorials.sort((a, b) => a.data.order - b.data.order);
 >
   <div class="tutorials-page">
     <div class="container">
-      <div class="section-heading" style="text-align: left; margin-bottom: 2.5rem;">
-        <p style="font-size: 0.8rem; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; color: var(--color-accent); margin-bottom: 0.5rem;">Learn</p>
-        <h1 style="font-size: clamp(1.75rem, 3vw, 2.5rem); letter-spacing: -0.02em; margin-bottom: 0.75rem;">Tutorials</h1>
-        <p style="color: var(--color-text-muted); font-size: 1.05rem; max-width: 560px; text-align: left; margin: 0;">
-          If you're brand new, start with <a href="/tutorials/getting-setup">Getting Setup</a> to
-          configure your development environment. Then explore the guides below.
+      <div class="coming-soon-block">
+        <h1>Tutorials</h1>
+        <p class="coming-soon-label">Coming Soon</p>
+        <p class="coming-soon-desc">
+          We're working on step-by-step guides covering neurotechnology, brain-computer interfaces,
+          machine learning, and more. Check back soon!
         </p>
-      </div>
-
-      <div class="tutorials-grid">
-        {tutorials.map((tutorial) => (
-          <div class="tutorial-card">
-            <a href={`/tutorials/${tutorial.slug}`}>
-              {tutorial.data.image && (
-                <img
-                  src={tutorial.data.image}
-                  alt={tutorial.data.title}
-                  class="tutorial-card-thumb"
-                />
-              )}
-              <div class="tutorial-card-body">
-                <div class="tutorial-card-title">{tutorial.data.title}</div>
-                <p class="tutorial-card-desc">{tutorial.data.description}</p>
-                {tutorial.data.draft && (
-                  <span class="tutorial-card-draft">Coming soon</span>
-                )}
-              </div>
-            </a>
-          </div>
-        ))}
+        <a href="/" class="btn btn-ghost" style="margin-top: 1.5rem;">Back to Home</a>
       </div>
     </div>
   </div>
 </BaseLayout>
+
+<style>
+  .coming-soon-block {
+    max-width: 540px;
+    margin: 6rem auto;
+    text-align: center;
+  }
+
+  .coming-soon-block h1 {
+    font-size: clamp(1.75rem, 3vw, 2.5rem);
+    letter-spacing: -0.02em;
+    margin-bottom: 1.25rem;
+  }
+
+  .coming-soon-label {
+    display: inline-block;
+    background: var(--color-accent-dim);
+    color: var(--color-accent);
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 0.35em 0.9em;
+    border-radius: 999px;
+    border: 1px solid var(--color-accent);
+    margin-bottom: 1.25rem;
+  }
+
+  .coming-soon-desc {
+    color: var(--color-text);
+    font-size: 1.05rem;
+    line-height: 1.7;
+    margin: 0;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Tutorials index replaced with a clean "Coming Soon" banner — no card grid, no "LEARN" eyebrow label
- Individual tutorial URLs (e.g. `/tutorials/getting-setup`) now redirect to `/tutorials` so old content is not accessible

## Test plan
- [ ] `/tutorials` shows the Coming Soon banner
- [ ] Visiting any old tutorial URL (e.g. `/tutorials/getting-setup`) redirects to `/tutorials`

🤖 Generated with [Claude Code](https://claude.com/claude-code)